### PR TITLE
feat: desktop 펫 기능 및 emotion animation 추가

### DIFF
--- a/src/main/kotlin/org/gitanimals/core/PersonaType.kt
+++ b/src/main/kotlin/org/gitanimals/core/PersonaType.kt
@@ -267,9 +267,26 @@ enum class PersonaType(
             .toString()
     },
 
-    LITTLE_CHICK(weight = 0.9, personaEvolution = PersonaEvolution(weight = 0.3, type = PersonaEvolutionType.LITTLE_CHICK)) {
+    LITTLE_CHICK(weight = 0.9, haveAnimation = true, personaEvolution = PersonaEvolution(weight = 0.3, type = PersonaEvolutionType.LITTLE_CHICK)) {
         override fun loadSvg(name: String, animationId: Long, level: Long, mode: Mode): String {
+            val emotion = buildEmotionAnimation(
+                idPrefix = "little-chick",
+                animationId = animationId,
+                totalDuration = 180.0,
+                emotionDuration = 3.0,
+                emotionSvgs = listOf(
+                    littleChickIdleFollowEmotionSvg,
+                    littleChickThinkingEmotionSvg,
+                    littleChickTypingEmotionSvg,
+                ),
+                emotionYOffsets = listOf(0.0, 0.0, 0.0),
+                minGap = 1.0,
+                maxGap = 1.0,
+            )
+
             val littleChick = littleChickSvg.replace("*{act}", act(animationId))
+                .replace("*{emotion-style}", emotion.css)
+                .replace("*{emotions}", emotion.content)
                 .replace("*{id}", animationId.toString())
                 .replace("*{leg-iteration-count}", "360")
                 .replace("*{level}", level.toSvg(14.0, 2.0))
@@ -293,9 +310,26 @@ enum class PersonaType(
             .toString()
     },
 
-    LITTLE_CHICK_SUNGLASSES(weight = 0.4, personaEvolution = PersonaEvolution(weight = 0.4, type = PersonaEvolutionType.LITTLE_CHICK)) {
+    LITTLE_CHICK_SUNGLASSES(weight = 0.4, haveAnimation = true, personaEvolution = PersonaEvolution(weight = 0.4, type = PersonaEvolutionType.LITTLE_CHICK)) {
         override fun loadSvg(name: String, animationId: Long, level: Long, mode: Mode): String {
+            val emotion = buildEmotionAnimation(
+                idPrefix = "little-chick",
+                animationId = animationId,
+                totalDuration = 180.0,
+                emotionDuration = 3.0,
+                emotionSvgs = listOf(
+                    littleChickIdleFollowEmotionSvg,
+                    littleChickThinkingEmotionSvg,
+                    littleChickTypingEmotionSvg,
+                ),
+                emotionYOffsets = listOf(0.0, 0.0, 0.0),
+                minGap = 1.0,
+                maxGap = 1.0,
+            )
+
             val littleChick = littleChickSunglassesSvg.replace("*{act}", act(animationId))
+                .replace("*{emotion-style}", emotion.css)
+                .replace("*{emotions}", emotion.content)
                 .replace("*{id}", animationId.toString())
                 .replace("*{leg-iteration-count}", "360")
                 .replace("*{level}", level.toSvg(14.0, 2.0))
@@ -2459,9 +2493,29 @@ enum class PersonaType(
             .toString()
     },
 
-    CAPYBARA_CARROT(0.6) {
+    CAPYBARA_CARROT(0.6, haveAnimation = true) {
         override fun loadSvg(name: String, animationId: Long, level: Long, mode: Mode): String {
+            val emotion = buildEmotionAnimation(
+                idPrefix = "capybara-carrot",
+                animationId = animationId,
+                totalDuration = 180.0,
+                emotionDuration = 3.0,
+                emotionSvgs = listOf(
+                    capybaraCarrotErrorEmotionSvg,
+                    capybaraCarrotHappyEmotionSvg,
+                    capybaraCarrotIdleFollowEmotionSvg,
+                    capybaraCarrotNotificationEmotionSvg,
+                    capybaraCarrotThinkingEmotionSvg,
+                    capybaraCarrotTypingEmotionSvg,
+                ),
+                emotionYOffsets = listOf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                minGap = 1.0,
+                maxGap = 1.0,
+            )
+
             return capybaraCarrotSvg.replace("*{act}", act(animationId))
+                .replace("*{emotion-style}", emotion.css)
+                .replace("*{emotions}", emotion.content)
                 .replace("*{id}", animationId.toString())
                 .replace("*{leg-iteration-count}", "360")
                 .replace("*{level}", level.toSvg(14.0, 2.0))

--- a/src/main/kotlin/org/gitanimals/core/Svgs.kt
+++ b/src/main/kotlin/org/gitanimals/core/Svgs.kt
@@ -114,6 +114,18 @@ val littleChickLinuxSvg: String = ClassPathResource("persona/animal/little-chick
 val littleChickSpringSvg: String = ClassPathResource("persona/animal/little-chick-spring.svg")
     .getContentAsString(Charset.defaultCharset())
 
+val littleChickIdleFollowEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/little-chick/idle-follow.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val littleChickThinkingEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/little-chick/thinking.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val littleChickTypingEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/little-chick/typing.svg")
+        .getContentAsString(Charset.defaultCharset())
+
 val penguinSvg: String = ClassPathResource("persona/animal/penguin.svg")
     .getContentAsString(Charset.defaultCharset())
 
@@ -376,6 +388,30 @@ val capybaraCarrotSvg: String = ClassPathResource("persona/animal/capybara-carro
 
 val capybaraSwimSvg: String = ClassPathResource("persona/animal/capybara-swim.svg")
     .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotErrorEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/error.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotHappyEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/happy.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotIdleFollowEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/idle-follow.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotNotificationEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/notification.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotThinkingEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/thinking.svg")
+        .getContentAsString(Charset.defaultCharset())
+
+val capybaraCarrotTypingEmotionSvg: String =
+    ClassPathResource("persona/animal/emotion/capybara-carrot/typing.svg")
+        .getContentAsString(Charset.defaultCharset())
 
 val littleChickEggOnHatSvg: String = ClassPathResource("persona/animal/evolution/little-chick-egg-on-hat.svg")
     .getContentAsString(Charset.defaultCharset())

--- a/src/main/resources/persona/animal/capybara-carrot.svg
+++ b/src/main/resources/persona/animal/capybara-carrot.svg
@@ -1,5 +1,6 @@
 <style>
   *{act}
+  *{emotion-style}
 
   @keyframes capybara-*{id}-carrot-move {
   0% {
@@ -140,6 +141,7 @@
 </g>
 
 <svg width="600" height="300" viewBox="0 0 200 100" fill="none" overflow="visible">
+  <g id="capybara-carrot-*{id}-base">
   <g id="capybara-*{id}-shadow" transform="translate(-4.2, 14.5)">
     <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447"
       fill-opacity="0.1"/>
@@ -179,5 +181,7 @@
     <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
     <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
   </g>
+  </g>
+  *{emotions}
 </svg>
 </g>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/error.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/error.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — error
+    Damped left-right shake + X eyes (alternating) + red ! flash
+  -->
+  <style>
+    @keyframes cap-error-obj {
+      0%        { transform: translate(0, 0); }
+      7%        { transform: translate(-1.5px, 0); }
+      14%       { transform: translate(1.5px, 0); }
+      21%       { transform: translate(-1.5px, 0); }
+      28%       { transform: translate(1.5px, 0); }
+      35%       { transform: translate(-1px, 0); }
+      42%       { transform: translate(1px, 0); }
+      49%       { transform: translate(-0.5px, 0); }
+      56%       { transform: translate(0.5px, 0); }
+      63%, 100% { transform: translate(0, 0); }
+    }
+    @keyframes cap-error-shadow {
+      0%        { transform: translate(-4.2px, 14.5px); }
+      7%        { transform: translate(-5.7px, 14.5px); }
+      14%       { transform: translate(-2.7px, 14.5px); }
+      21%       { transform: translate(-5.7px, 14.5px); }
+      28%       { transform: translate(-2.7px, 14.5px); }
+      35%       { transform: translate(-5.2px, 14.5px); }
+      42%       { transform: translate(-3.2px, 14.5px); }
+      49%       { transform: translate(-4.7px, 14.5px); }
+      56%       { transform: translate(-3.7px, 14.5px); }
+      63%, 100% { transform: translate(-4.2px, 14.5px); }
+    }
+    @keyframes cap-error-flash {
+      0%, 100% { opacity: 1; }
+      50%      { opacity: 0.15; }
+    }
+    @keyframes cap-error-eyes-normal {
+      0%, 20%   { opacity: 1; }
+      25%       { opacity: 0; }
+      65%       { opacity: 0; }
+      70%, 100% { opacity: 1; }
+    }
+    @keyframes cap-error-eyes-x {
+      0%, 20%   { opacity: 0; }
+      25%       { opacity: 1; }
+      65%       { opacity: 1; }
+      70%, 100% { opacity: 0; }
+    }
+
+    #cap-error-shadow { animation: cap-error-shadow 3s ease-in-out infinite; }
+    #cap-error-obj    { animation: cap-error-obj 3s ease-in-out infinite; }
+    #cap-error-eyes-n { animation: cap-error-eyes-normal 1.5s steps(1, end) infinite; }
+    #cap-error-eyes-x { animation: cap-error-eyes-x 1.5s steps(1, end) infinite; }
+    .cap-error-flash  { animation: cap-error-flash 0.8s ease-in-out infinite; }
+  </style>
+
+  <!-- Shadow (x synced with shake) -->
+  <g id="cap-error-shadow" transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <g id="cap-error-obj">
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <g transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <g transform="translate(0, 0)">
+      <g>
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <!-- Normal eyes -->
+        <g id="cap-error-eyes-n">
+          <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+        </g>
+        <!-- X eye (single — larger, thicker) -->
+        <g id="cap-error-eyes-x" opacity="0">
+          <rect x="5.51" y="3.49" width="0.8" height="3.6" transform="rotate(45 5.91 5.29)" fill="black"/>
+          <rect x="5.51" y="3.49" width="0.8" height="3.6" transform="rotate(-45 5.91 5.29)" fill="black"/>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- Red ! alert bubble (outside obj) -->
+  <g transform="translate(14, -8)">
+    <g fill="white" fill-opacity="0.92">
+      <rect x="1" y="0" width="4" height="5"/>
+      <rect x="0" y="1" width="6" height="3"/>
+      <rect x="1" y="5" width="2" height="1"/>
+      <rect x="0" y="6" width="1" height="1"/>
+    </g>
+    <rect class="cap-error-flash" x="2.5" y="1" width="1" height="2" fill="#FF4444"/>
+    <rect class="cap-error-flash" x="2.5" y="3.5" width="1" height="1" fill="#FF4444"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/happy.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/happy.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — happy (attention state)
+    Jump + ^^ eyes alternating with normal + sparkles
+  -->
+  <defs>
+    <g id="cap-happy-px-sparkle">
+      <rect class="cap-happy-spark-c" x="-0.5" y="-0.5" width="1" height="1"/>
+      <g class="cap-happy-spark-o">
+        <rect x="-0.5" y="-1.5" width="1" height="1"/>
+        <rect x="-0.5" y="0.5"  width="1" height="1"/>
+        <rect x="-1.5" y="-0.5" width="1" height="1"/>
+        <rect x="0.5"  y="-0.5" width="1" height="1"/>
+      </g>
+    </g>
+  </defs>
+  <style>
+    @keyframes cap-happy-obj {
+      0%, 15%, 100% { transform: translate(0, 0); }
+      40%  { transform: translate(0, -8px); }
+      50%  { transform: translate(0, -10px); }
+      60%  { transform: translate(0, -8px); }
+      80%  { transform: translate(0, 0); }
+    }
+    @keyframes cap-happy-shadow {
+      0%, 15%, 100% { transform: translate(-4.2px, 14.5px) scaleX(1);   opacity: 0.8; }
+      40%  { transform: translate(-4.2px, 14.5px) scaleX(0.55); opacity: 0.25; }
+      50%  { transform: translate(-4.2px, 14.5px) scaleX(0.5);  opacity: 0.2; }
+      60%  { transform: translate(-4.2px, 14.5px) scaleX(0.55); opacity: 0.25; }
+      80%  { transform: translate(-4.2px, 14.5px) scaleX(1);    opacity: 0.8; }
+    }
+    @keyframes cap-happy-eyes-normal {
+      0%, 20%   { opacity: 1; }
+      25%       { opacity: 0; }
+      65%       { opacity: 0; }
+      70%, 100% { opacity: 1; }
+    }
+    @keyframes cap-happy-eyes-arc {
+      0%, 20%   { opacity: 0; }
+      25%       { opacity: 1; }
+      65%       { opacity: 1; }
+      70%, 100% { opacity: 0; }
+    }
+    @keyframes cap-happy-spark-center {
+      0% { opacity: 0; } 10% { opacity: 1; } 30% { opacity: 0; } 100% { opacity: 0; }
+    }
+    @keyframes cap-happy-spark-outer {
+      0% { opacity: 0; } 20% { opacity: 1; } 40% { opacity: 0; } 100% { opacity: 0; }
+    }
+
+    #cap-happy-shadow  { animation: cap-happy-shadow 1.5s ease-in-out infinite; }
+    #cap-happy-obj     { animation: cap-happy-obj 1.5s ease-in-out infinite; }
+    #cap-happy-eyes-n  { animation: cap-happy-eyes-normal 1.5s steps(1, end) infinite; }
+    #cap-happy-eyes-a  { animation: cap-happy-eyes-arc 1.5s steps(1, end) infinite; }
+    .cap-happy-spark-c { opacity: 0; animation: cap-happy-spark-center 1.5s infinite step-end; animation-delay: var(--d, 0s); }
+    .cap-happy-spark-o { opacity: 0; animation: cap-happy-spark-outer  1.5s infinite step-end; animation-delay: var(--d, 0s); }
+  </style>
+
+  <!-- Shadow -->
+  <g id="cap-happy-shadow" transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <g id="cap-happy-obj">
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <g transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <g transform="translate(0, 0)">
+      <g>
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <!-- Normal eyes -->
+        <g id="cap-happy-eyes-n">
+          <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+        </g>
+        <!-- ^ arc eye (single, thick gentle curve) -->
+        <g id="cap-happy-eyes-a" opacity="0">
+          <rect x="5.21" y="5.29" width="0.8" height="0.8" fill="black"/>
+          <rect x="5.51" y="4.94" width="0.8" height="0.8" fill="black"/>
+          <rect x="5.91" y="4.74" width="0.8" height="0.8" fill="black"/>
+          <rect x="6.31" y="4.94" width="0.8" height="0.8" fill="black"/>
+          <rect x="6.61" y="5.29" width="0.8" height="0.8" fill="black"/>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <!-- Sparkles (outside obj) -->
+  <use href="#cap-happy-px-sparkle" x="-2" y="-8"  fill="#FFD700" style="--d: 0.0s"/>
+  <use href="#cap-happy-px-sparkle" x="18" y="-6"  fill="#FFA000" style="--d: 0.3s"/>
+  <use href="#cap-happy-px-sparkle" x="16" y="8"   fill="#FFD700" style="--d: 0.6s"/>
+</svg>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/idle-follow.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/idle-follow.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — base idle (head nod only)
+    Ported from capybara-carrot.svg (GitAnimals template)
+    Unique keyframe prefix "cap-base-" to avoid collisions
+  -->
+  <style>
+    @keyframes cap-base-head-nod {
+      0%   { transform: translate(0, 0); }
+      50%  { transform: translate(0.5px, 0); }
+      100% { transform: translate(0, 0); }
+    }
+    @keyframes cap-base-carrot {
+      0%   { transform: translate(5.2px, -3.8px); }
+      50%  { transform: translate(5.7px, -3.8px); }
+      100% { transform: translate(5.2px, -3.8px); }
+    }
+    #cap-base-head-nod { animation: cap-base-head-nod 1s ease-in-out infinite; }
+    #cap-base-carrot   { animation: cap-base-carrot 1s ease-in-out infinite; }
+  </style>
+
+  <!-- Shadow -->
+  <g transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <!-- obj -->
+  <g>
+    <!-- Legs (static) -->
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <!-- Body -->
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <!-- Carrot (synced with head nod) -->
+    <g id="cap-base-carrot" transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <!-- Head: outer=position, inner=delta -->
+    <g transform="translate(0, 0)">
+      <g id="cap-base-head-nod">
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <!-- Eyes -->
+        <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/notification.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/notification.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — notification
+    Damped surprise bounce (3 bounces) + ! pop-in bubble
+  -->
+  <style>
+    @keyframes cap-notif-obj {
+      0%          { transform: translate(0, 0); }
+      10%         { transform: translate(0, 1px); }
+      20%         { transform: translate(0, -9px); }
+      28%         { transform: translate(0, 1.5px); }
+      35%         { transform: translate(0, -5px); }
+      42%         { transform: translate(0, 1px); }
+      48%         { transform: translate(0, -2px); }
+      53%         { transform: translate(0, 0); }
+      72%         { transform: translate(0, -2.5px); }
+      80%, 100%   { transform: translate(0, 0); }
+    }
+    @keyframes cap-notif-shadow {
+      0%          { transform: translate(-4.2px, 14.5px) scaleX(1); }
+      10%         { transform: translate(-4.2px, 14.5px) scaleX(1.1); }
+      20%         { transform: translate(-4.2px, 14.5px) scaleX(0.5); }
+      28%         { transform: translate(-4.2px, 14.5px) scaleX(1.1); }
+      35%         { transform: translate(-4.2px, 14.5px) scaleX(0.7); }
+      42%         { transform: translate(-4.2px, 14.5px) scaleX(1.05); }
+      48%         { transform: translate(-4.2px, 14.5px) scaleX(0.85); }
+      53%         { transform: translate(-4.2px, 14.5px) scaleX(1); }
+      72%         { transform: translate(-4.2px, 14.5px) scaleX(1.1); }
+      80%, 100%   { transform: translate(-4.2px, 14.5px) scaleX(1); }
+    }
+    @keyframes cap-notif-alert {
+      0%    { transform: translate(16px, -6px) scale(0);   opacity: 0; }
+      8%    { transform: translate(16px, -6px) scale(1.3); opacity: 1; }
+      14%   { transform: translate(16px, -6px) scale(1);   opacity: 1; }
+      65%   { transform: translate(16px, -6px) scale(1);   opacity: 1; }
+      75%   { transform: translate(16px, -6px) scale(0.7); opacity: 0; }
+      100%  { transform: translate(16px, -6px) scale(0);   opacity: 0; }
+    }
+
+    #cap-notif-shadow { animation: cap-notif-shadow 3.5s ease-in-out infinite; }
+    #cap-notif-obj    { animation: cap-notif-obj 3.5s ease-in-out infinite; }
+    #cap-notif-alert  { animation: cap-notif-alert 3.5s ease-in-out infinite; }
+  </style>
+
+  <!-- Shadow -->
+  <g id="cap-notif-shadow" transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <g id="cap-notif-obj">
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <g transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <g transform="translate(0, 0)">
+      <g>
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Floating ! (outside obj — no bubble) -->
+  <g id="cap-notif-alert" transform="translate(16, -6)">
+    <rect x="0" y="0" width="1.2" height="3" fill="#FF8C00"/>
+    <rect x="0" y="3.8" width="1.2" height="1.2" fill="#FF8C00"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/thinking.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/thinking.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — thinking
+    Static body + thought bubble with sequential loading dots
+  -->
+  <style>
+    @keyframes cap-think-bubble {
+      0%   { transform: translate(13px, -10px); }
+      50%  { transform: translate(13px, -10.3px); }
+      100% { transform: translate(13px, -10px); }
+    }
+    @keyframes cap-think-dot-1 { 0%, 20% { opacity: 0; } 21%, 100% { opacity: 1; } }
+    @keyframes cap-think-dot-2 { 0%, 40% { opacity: 0; } 41%, 100% { opacity: 1; } }
+    @keyframes cap-think-dot-3 { 0%, 60% { opacity: 0; } 61%, 100% { opacity: 1; } }
+
+    #cap-think-bubble { animation: cap-think-bubble 2s ease-in-out infinite; }
+    #cap-think-d1 { opacity: 0; animation: cap-think-dot-1 2s ease-in-out infinite; }
+    #cap-think-d2 { opacity: 0; animation: cap-think-dot-2 2s ease-in-out infinite; }
+    #cap-think-d3 { opacity: 0; animation: cap-think-dot-3 2s ease-in-out infinite; }
+  </style>
+
+  <!-- Shadow -->
+  <g transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <g>
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <g transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <g transform="translate(0, 0)">
+      <g>
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Thought bubble (outside obj — independent bob) -->
+  <g id="cap-think-bubble" transform="translate(13, -10)">
+    <g fill="white" fill-opacity="0.92">
+      <rect x="1" y="0" width="7" height="6"/>
+      <rect x="0" y="1" width="9" height="4"/>
+      <rect x="1" y="6" width="3" height="1"/>
+      <rect x="0" y="7" width="1" height="1"/>
+    </g>
+    <rect id="cap-think-d1" x="2" y="2.5" width="1" height="1" fill="#888"/>
+    <rect id="cap-think-d2" x="4.5" y="2.5" width="1" height="1" fill="#888"/>
+    <rect id="cap-think-d3" x="7" y="2.5" width="1" height="1" fill="#888"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/capybara-carrot/typing.svg
+++ b/src/main/resources/persona/animal/emotion/capybara-carrot/typing.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45">
+  <!--
+    Capybara Carrot — typing (working state)
+    Head slight nod + carrot vibrate (typing feel)
+  -->
+  <style>
+    @keyframes cap-typing-head-nod {
+      0%   { transform: translate(0, 0); }
+      50%  { transform: translate(0.3px, 0); }
+      100% { transform: translate(0, 0); }
+    }
+    @keyframes cap-typing-carrot {
+      0%   { transform: translate(5.2px, -3.8px); }
+      50%  { transform: translate(5.2px, -4.0px); }
+      100% { transform: translate(5.2px, -3.8px); }
+    }
+    @keyframes cap-typing-notebook {
+      0%   { transform: translate(13px, 8px) scale(1.8); }
+      50%  { transform: translate(13px, 8.2px) scale(1.8); }
+      100% { transform: translate(13px, 8px) scale(1.8); }
+    }
+    #cap-typing-head-nod { animation: cap-typing-head-nod 0.8s ease-in-out infinite; }
+    #cap-typing-carrot   { animation: cap-typing-carrot 0.3s ease-in-out infinite; }
+    #cap-typing-notebook { animation: cap-typing-notebook 0.3s ease-in-out infinite; }
+  </style>
+
+  <!-- Shadow -->
+  <g transform="translate(-4.2, 14.5)">
+    <rect width="20" height="2.5" transform="matrix(-1 0 0 1 20 1.83252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 1.20752)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="16.9231" height="0.625" transform="matrix(-1 0 0 1 18.4614 4.33252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 0.58252)" fill="#2B4447" fill-opacity="0.1"/>
+    <rect width="13.8462" height="0.625" transform="matrix(-1 0 0 1 16.9233 4.95752)" fill="#2B4447" fill-opacity="0.1"/>
+  </g>
+
+  <g>
+    <g transform="translate(3.8, 15)">
+      <path d="M8.08245 0.0825195H6.12369V2.62891H8.08245V0.0825195Z" fill="#C17B46"/>
+      <path d="M2.20617 0.0825195H0.247406V2.62891H2.20617V0.0825195Z" fill="#C17B46"/>
+    </g>
+    <g transform="translate(-2, 14)">
+      <path d="M4.28865 0.886719H0.371124V3.62898H4.28865V0.886719Z" fill="#C17B46"/>
+    </g>
+
+    <g transform="translate(-3.2, 6.1)">
+      <path d="M9.98971 0.876343H3.32993V4.59799H9.98971V0.876343Z" fill="#C17B46"/>
+      <path d="M15.0825 2.83508H0V10.6701H15.0825V2.83508Z" fill="#C17B46"/>
+      <path d="M15.0824 6.75256H7.24741V8.71132H15.0824V6.75256Z" fill="#A56235"/>
+      <path d="M13.1237 8.5155H9.20615V10.6701H13.1237V8.5155Z" fill="#A56235"/>
+      <path d="M7.24743 4.79382H5.28867V6.75258H7.24743V4.79382Z" fill="#A56235"/>
+    </g>
+
+    <g id="cap-typing-carrot" transform="translate(5.2, -3.8)">
+      <path d="M4.12371 0H2.16495V2.15464H4.12371V0Z" fill="#4AFF79"/>
+      <path d="M6.08243 1.95874H0.206146V6.07214H6.08243V1.95874Z" fill="#FF8948"/>
+    </g>
+
+    <g transform="translate(0, 0)">
+      <g id="cap-typing-head-nod">
+        <path d="M14.0412 0H11.299V2.54639H14.0412V0Z" fill="#8E654A"/>
+        <path d="M16 1.95886H2.28867V9.79391H16V1.95886Z" fill="#C17B46"/>
+        <path d="M16 9.01038H4.24741V11.7526H16V9.01038Z" fill="#C17B46"/>
+        <path d="M16 7.83508H8.16495V11.7526H16V7.83508Z" fill="#7C4B32"/>
+        <path d="M16 5.87634H10.1237V8.22686H16V5.87634Z" fill="#7C4B32"/>
+        <path d="M4.24745 0H0.329926V3.91752H4.24745V0Z" fill="#8E654A"/>
+        <path d="M7.38144 4.70105H4.4433V5.87631H7.38144V4.70105Z" fill="black"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Notebook (outside obj — fox-style, larger, right-bottom of head) -->
+  <g id="cap-typing-notebook" transform="translate(13, 8) scale(1.8)">
+    <rect width="4.66667" height="3.33333" transform="matrix(-1 0 0 1 6.6665 0)" fill="#E4E4E4"/>
+    <rect width="6" height="3.33333" transform="matrix(-1 0 0 1 7.33325 0.666687)" fill="#E4E4E4"/>
+    <rect width="6" height="1.33333" transform="matrix(-1 0 0 1 6.6665 2.66669)" fill="#E4E4E4"/>
+    <rect width="6" height="0.666667" transform="matrix(-1 0 0 1 6 3.33331)" fill="#E4E4E4"/>
+    <rect width="0.666667" height="1.33333" transform="matrix(-1 0 0 1 1.33325 2.66669)" fill="black" fill-opacity="0.1"/>
+    <rect width="0.666667" height="0.666667" transform="matrix(-1 0 0 1 0.666504 3.33331)" fill="black" fill-opacity="0.1"/>
+    <rect width="6" height="0.666667" transform="matrix(-1 0 0 1 7.33325 3.33331)" fill="black" fill-opacity="0.1"/>
+    <rect x="5.33325" y="2.33331" width="0.666667" height="0.333333" transform="rotate(180 5.33325 2.33331)" fill="#242427"/>
+    <rect width="0.666667" height="0.333333" transform="matrix(-1 0 0 1 5 1.66669)" fill="#242427"/>
+    <rect width="0.333333" height="1.33333" transform="matrix(-1 0 0 1 5.33325 1.33331)" fill="#242427"/>
+    <rect width="1" height="0.333333" transform="matrix(-1 0 0 1 5.33325 2.33331)" fill="#242427"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/little-chick/idle-follow.svg
+++ b/src/main/resources/persona/animal/emotion/little-chick/idle-follow.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" shape-rendering="crispEdges">
+  <!--
+    Little Chick — base idle (head bob + leg walk)
+    Keyframe prefix: lchick-base-
+  -->
+  <style>
+    @keyframes lchick-base-head {
+      0%   { transform: translate(6px, -2px) rotate(0deg); }
+      50%  { transform: translate(6.8px, -2.1px) rotate(8deg); }
+      100% { transform: translate(6px, -2px) rotate(0deg); }
+    }
+    @keyframes lchick-base-leg {
+      0%   { transform: translate(2px, 6px) rotate(0deg); }
+      50%  { transform: translate(2px, 6px) rotate(3deg); }
+      100% { transform: translate(2px, 6px) rotate(0deg); }
+    }
+    #little-chick-head {
+      animation-name: lchick-base-head;
+      animation-duration: 1.2s;
+      animation-iteration-count: infinite;
+    }
+    #lchick-base-leg {
+      animation-name: lchick-base-leg;
+      animation-duration: 0.5s;
+      animation-iteration-count: 360;
+      animation-timing-function: ease-in;
+    }
+  </style>
+
+  <!-- Leg -->
+  <g id="lchick-base-leg" transform="translate(2, 6)">
+    <rect width="2" height="2" fill="#FF6F0F"/>
+    <rect x="1" y="1" width="2" height="1" fill="#FF6F0F"/>
+  </g>
+
+  <!-- Body -->
+  <g id="lchick-base-body">
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 4)" fill="#FFD600"/>
+    <rect x="3" y="5" width="5" height="2" fill="#FFD600"/>
+    <rect width="9" height="3" transform="matrix(-1 0 0 1 12 4)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 11 8)" fill="#FFD600"/>
+    <rect width="7" height="1" transform="matrix(-1 0 0 1 11 7)" fill="#FFD600"/>
+    <rect width="4" height="1" transform="matrix(-1 0 0 1 10 9)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 3 5)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 5 0)" fill="#FFD600"/>
+    <rect width="7" height="2" transform="matrix(-1 0 0 1 7 2)" fill="#FFD600"/>
+    <rect x="1" y="2" width="5" height="2" fill="#FFD600"/>
+    <rect x="2" y="1" width="3" height="2" fill="#FFD600"/>
+    <rect x="2" y="3" width="5" height="2" fill="#FFD600"/>
+    <rect x="4" y="2" width="7" height="5" fill="#FFD600"/>
+    <rect x="5" y="7" width="5" height="1" fill="#FFD600"/>
+    <rect x="6" y="8" width="4" height="1" fill="#FFD600"/>
+  </g>
+
+  <!-- Head (animated — accessory anchor) -->
+  <g id="little-chick-head" transform="translate(6, -2)">
+    <rect x="1" y="1" width="4" height="6" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 1 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 5 1)" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 6 2)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 4 0)" fill="#FFD600"/>
+    <!-- Beak -->
+    <rect x="4" y="4" width="2" height="2" fill="#FF6F0F"/>
+    <rect x="5" y="5" width="2" height="1" fill="#FF6F0F"/>
+    <!-- Eyes -->
+    <rect x="2" y="3" width="1" height="1" fill="black"/>
+    <rect x="4" y="2" width="1" height="1" fill="black"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/little-chick/thinking.svg
+++ b/src/main/resources/persona/animal/emotion/little-chick/thinking.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" shape-rendering="crispEdges">
+  <!--
+    Little Chick — thinking (slow head bob, no leg movement)
+    Keyframe prefix: lchick-think-
+  -->
+  <style>
+    @keyframes lchick-think-head {
+      0%   { transform: translate(6px, -2px) rotate(0deg); }
+      50%  { transform: translate(6.5px, -2.05px) rotate(5deg); }
+      100% { transform: translate(6px, -2px) rotate(0deg); }
+    }
+    #little-chick-head {
+      animation-name: lchick-think-head;
+      animation-duration: 1.8s;
+      animation-iteration-count: infinite;
+    }
+  </style>
+
+  <!-- Leg (static) -->
+  <g transform="translate(2, 6)">
+    <rect width="2" height="2" fill="#FF6F0F"/>
+    <rect x="1" y="1" width="2" height="1" fill="#FF6F0F"/>
+  </g>
+
+  <!-- Body -->
+  <g>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 4)" fill="#FFD600"/>
+    <rect x="3" y="5" width="5" height="2" fill="#FFD600"/>
+    <rect width="9" height="3" transform="matrix(-1 0 0 1 12 4)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 11 8)" fill="#FFD600"/>
+    <rect width="7" height="1" transform="matrix(-1 0 0 1 11 7)" fill="#FFD600"/>
+    <rect width="4" height="1" transform="matrix(-1 0 0 1 10 9)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 3 5)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 5 0)" fill="#FFD600"/>
+    <rect width="7" height="2" transform="matrix(-1 0 0 1 7 2)" fill="#FFD600"/>
+    <rect x="1" y="2" width="5" height="2" fill="#FFD600"/>
+    <rect x="2" y="1" width="3" height="2" fill="#FFD600"/>
+    <rect x="2" y="3" width="5" height="2" fill="#FFD600"/>
+    <rect x="4" y="2" width="7" height="5" fill="#FFD600"/>
+    <rect x="5" y="7" width="5" height="1" fill="#FFD600"/>
+    <rect x="6" y="8" width="4" height="1" fill="#FFD600"/>
+  </g>
+
+  <!-- Head (slow bob — accessory anchor) -->
+  <g id="little-chick-head" transform="translate(6, -2)">
+    <rect x="1" y="1" width="4" height="6" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 1 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 5 1)" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 6 2)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 4 0)" fill="#FFD600"/>
+    <!-- Beak -->
+    <rect x="4" y="4" width="2" height="2" fill="#FF6F0F"/>
+    <rect x="5" y="5" width="2" height="1" fill="#FF6F0F"/>
+    <!-- Eyes -->
+    <rect x="2" y="3" width="1" height="1" fill="black"/>
+    <rect x="4" y="2" width="1" height="1" fill="black"/>
+  </g>
+</svg>

--- a/src/main/resources/persona/animal/emotion/little-chick/typing.svg
+++ b/src/main/resources/persona/animal/emotion/little-chick/typing.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" shape-rendering="crispEdges">
+  <!--
+    Little Chick — working/typing (sitting with notebook)
+    Head nods at notebook, legs static, notebook vibrates slightly
+    Keyframe prefix: lchick-type-
+  -->
+  <style>
+    @keyframes lchick-type-head {
+      0%   { transform: translate(6px, -2px) rotate(0deg); }
+      50%  { transform: translate(7px, -2.1px) rotate(10deg); }
+      100% { transform: translate(6px, -2px) rotate(0deg); }
+    }
+    #little-chick-head {
+      animation-name: lchick-type-head;
+      animation-duration: 0.9s;
+      animation-iteration-count: infinite;
+    }
+  </style>
+
+  <!-- Leg (static — sitting) -->
+  <g transform="translate(2, 6)">
+    <rect width="2" height="2" fill="#FF6F0F"/>
+    <rect x="1" y="1" width="2" height="1" fill="#FF6F0F"/>
+  </g>
+
+  <!-- Body -->
+  <g>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 4)" fill="#FFD600"/>
+    <rect x="3" y="5" width="5" height="2" fill="#FFD600"/>
+    <rect width="9" height="3" transform="matrix(-1 0 0 1 12 4)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 11 8)" fill="#FFD600"/>
+    <rect width="7" height="1" transform="matrix(-1 0 0 1 11 7)" fill="#FFD600"/>
+    <rect width="4" height="1" transform="matrix(-1 0 0 1 10 9)" fill="#FFD600"/>
+    <rect width="6" height="1" transform="matrix(-1 0 0 1 7 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 3 5)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 5 0)" fill="#FFD600"/>
+    <rect width="7" height="2" transform="matrix(-1 0 0 1 7 2)" fill="#FFD600"/>
+    <rect x="1" y="2" width="5" height="2" fill="#FFD600"/>
+    <rect x="2" y="1" width="3" height="2" fill="#FFD600"/>
+    <rect x="2" y="3" width="5" height="2" fill="#FFD600"/>
+    <rect x="4" y="2" width="7" height="5" fill="#FFD600"/>
+    <rect x="5" y="7" width="5" height="1" fill="#FFD600"/>
+    <rect x="6" y="8" width="4" height="1" fill="#FFD600"/>
+  </g>
+
+  <!-- Head (nods at notebook — accessory anchor) -->
+  <g id="little-chick-head" transform="translate(6, -2)">
+    <rect x="1" y="1" width="4" height="6" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 1 1)" fill="#FFD600"/>
+    <rect width="1" height="1" transform="matrix(-1 0 0 1 5 1)" fill="#FFD600"/>
+    <rect width="1" height="4" transform="matrix(-1 0 0 1 6 2)" fill="#FFD600"/>
+    <rect width="3" height="1" transform="matrix(-1 0 0 1 4 0)" fill="#FFD600"/>
+    <!-- Beak -->
+    <rect x="4" y="4" width="2" height="2" fill="#FF6F0F"/>
+    <rect x="5" y="5" width="2" height="1" fill="#FF6F0F"/>
+    <!-- Eyes -->
+    <rect x="2" y="3" width="1" height="1" fill="black"/>
+    <rect x="4" y="2" width="1" height="1" fill="black"/>
+  </g>
+
+  <!-- Notebook injected as accessory (acc-notebook.svg) via theme.json anchors -->
+</svg>

--- a/src/main/resources/persona/animal/little-chick-sunglasses.svg
+++ b/src/main/resources/persona/animal/little-chick-sunglasses.svg
@@ -1,6 +1,6 @@
 <style>
   *{act}
-
+  *{emotion-style}
 
   @keyframes little-chick-move-head {
   0% {
@@ -126,6 +126,7 @@
 
 <svg width="600" height="300" viewBox="0 0 300 150" fill="none" overflow="visible"
   xmlns="http://www.w3.org/2000/svg">
+  <g id="little-chick-*{id}-base">
   <g id="little-chick-shadow" transform="translate(-2, 2)">
     <rect width="12" height="3"
       transform="matrix(0.707107 0.707107 0.707107 -0.707107 1.41422 2.12132)" fill="#6F6F6F"
@@ -211,5 +212,7 @@
     <rect x="8.05104" y="4.02853" width="0.428571" height="0.428571"
       transform="rotate(-13.8199 8.05104 4.02853)" fill="white"/>
   </g>
+  </g>
+  *{emotions}
 </svg>
 </g>

--- a/src/main/resources/persona/animal/little-chick.svg
+++ b/src/main/resources/persona/animal/little-chick.svg
@@ -1,6 +1,6 @@
 <style>
   *{act}
-
+  *{emotion-style}
 
   @keyframes little-chick-move-head {
   0% {
@@ -126,6 +126,7 @@
 
 <svg width="600" height="300" viewBox="0 0 300 150" fill="none" overflow="visible"
   xmlns="http://www.w3.org/2000/svg">
+  <g id="little-chick-*{id}-base">
   <g id="little-chick-shadow" transform="translate(-2, 2)">
     <rect width="12" height="3"
       transform="matrix(0.707107 0.707107 0.707107 -0.707107 1.41422 2.12132)" fill="#6F6F6F"
@@ -180,5 +181,7 @@
     <rect x="4" y="4" width="2" height="2" fill="#FF6F0F"/>
     <rect x="5" y="5" width="2" height="1" fill="#FF6F0F"/>
   </g>
+  </g>
+  *{emotions}
 </svg>
 </g>


### PR DESCRIPTION
## Summary

- Desktop 펫 조회 API 추가 (`feat: Desktop 펫 조회기능 추가`)
- Asset download API 추가
- gitanimals render에 애니메이션 포함
- `CAPYBARA_CARROT`, `LITTLE_CHICK`, `LITTLE_CHICK_SUNGLASSES`에 emotion animation 추가
  - CAPYBARA_CARROT: error / happy / idle-follow / notification / thinking / typing (6종)
  - LITTLE_CHICK / LITTLE_CHICK_SUNGLASSES: idle-follow / thinking / typing (3종) 공유

## Test plan

- [ ] `CAPYBARA_CARROT` 렌더 엔드포인트 호출 후 브라우저에서 SVG 열어 180초간 emotion 6종 cycling 확인
- [ ] `LITTLE_CHICK`, `LITTLE_CHICK_SUNGLASSES` 동일 확인
- [ ] Desktop 펫 조회 API 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)